### PR TITLE
docs: fix Go-based installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ makepkg -si
 
 ### Go
 
-`go install github.com/mJehanno/gtop@latest`
+`go install github.com/mjehanno/gtop@latest`
 
 ### Tarball
 


### PR DESCRIPTION
Hi! Just a tiny fix to the installation instructions (with the current ones I get the following):

```
$ go install github.com/mJehanno/gtop@latest
go: github.com/mJehanno/gtop@latest: github.com/mJehanno/gtop@v0.0.0-20230226065907-31fdaff5cc0f: parsing go.mod:
	module declares its path as: github.com/mjehanno/gtop
	       but was required as: github.com/mJehanno/gtop
```